### PR TITLE
fixed support ledger

### DIFF
--- a/app/scripts/uiFuncs.js
+++ b/app/scripts/uiFuncs.js
@@ -177,16 +177,20 @@ uiFuncs.generateTx = function(txData, callback) {
                             error: error
                         });
                         return;
+                    }else if (rawTx.chainId === 31102) {
+                        EIP155Supported = false; 
                     }
-                    var splitVersion = result['version'].split('.');
-                    if (parseInt(splitVersion[0]) > 1) {
-                        EIP155Supported = true;
-                    } else
-                    if (parseInt(splitVersion[1]) > 0) {
-                        EIP155Supported = true;
-                    } else
-                    if (parseInt(splitVersion[2]) > 2) {
-                        EIP155Supported = true;
+                    else	{
+                        var splitVersion = result['version'].split('.');
+                        if (parseInt(splitVersion[0]) > 1) {
+                            EIP155Supported = true;
+                        } else
+                        if (parseInt(splitVersion[1]) > 0) {
+                            EIP155Supported = true;
+                        } else
+                        if (parseInt(splitVersion[2]) > 2) {
+                            EIP155Supported = true;
+                        }
                     }
                     uiFuncs.signTxLedger(app, eTx, rawTx, txData, !EIP155Supported, callback);
                 }


### PR DESCRIPTION
add
                    }else if (rawTx.chainId === 31102) {
                           EIP155Supported = false; 
                    }

fixed support ledger

**
나노렛저s를 지원하기 위한 코드 추가, 기존의 invalid sender 에러를 해결한다.
내부적으로 코드사이닝이 제대로 안되서 발생하는 문제.
칼리스토처럼 eip155를 꺼서 문제를 회피하였다.
해당 패치를 통해 
http://wallet.gonspool.com 에서 전송테스트를 하였다.
https://escblock.gonsmine.com/tx/0x32961c65e12f7baeae8dfd6f4b9072db31144c6b71fa026c4617d64969567e2a 실제 전송한 결과의 tx 링크이다.
